### PR TITLE
Improve logging with tqdm

### DIFF
--- a/src/csne/csne.py
+++ b/src/csne/csne.py
@@ -23,7 +23,7 @@ import pandas as pd
 import scipy.sparse as sparse
 from scipy.optimize import minimize
 from sklearn.metrics import roc_auc_score
-from tqdm import tqdm
+from tqdm import tqdm, trange
 import time
 
 
@@ -137,10 +137,9 @@ class CSNE:
 
     def optimizer_adam(self, X, num_epochs=100, alpha=0.001, beta_1=0.9,
                        beta_2=0.9999, eps=1e-8, verbose=True, epsilon=0.01):
-        print("Starting CSNE training...")
         m_prev = np.zeros_like(X)
         v_prev = np.zeros_like(X)
-        for epoch in range(num_epochs):
+        for epoch in trange(num_epochs, desc='Training CSNE'):
             grad = -self._eval_grad(X, epsilon=epsilon)
 
             # Adam optimizer
@@ -157,11 +156,11 @@ class CSNE:
             if verbose:
                 if epoch % 1 == 0:
                     grad_norm = np.sum(grad**2)**.5
-                    print('Epoch: {:d}, gradient norm: {:.4f}'.format(epoch, grad_norm))
+                    tqdm.write('Epoch: {:d}, gradient norm: {:.4f}'.format(epoch, grad_norm))
                 if epoch == num_epochs-1:
                     grad_norm = np.sum(grad**2)**.5
                     obj = self._eval_obj(X)
-                    print('Epoch: {:d}, obj: {:.4f}, gradient norm: {:.4f}'.format(epoch, -obj, grad_norm))
+                    tqdm.write('Epoch: {:d}, obj: {:.4f}, gradient norm: {:.4f}'.format(epoch, -obj, grad_norm))
         return X
 
     def fit(self, verbose=True, X0=None):

--- a/src/csne/csne.py
+++ b/src/csne/csne.py
@@ -61,8 +61,7 @@ class CSNE:
         self.__num_pos_sample_list = []
         self.__prior_ratio = []
 
-        print('start neighborhood sampling')
-        for i in tqdm(range(self.__n)):
+        for i in trange(self.__n, desc='Neighborhood sampling'):
             if samplemask is None:
                 samples = []
                 pos_ids = self.__adj_list[i]
@@ -93,8 +92,6 @@ class CSNE:
                 self.__edge_masks.append(aux > 0.5)
                 P = self.__prior.get_row_probability(i, sample_ids)
                 self.__prior_ratio.append((1-P)/P)
-
-        print('finish neighborhood sampling')
 
     def _compute_squared_dist(self, X, target_id, sample_ids):
         return np.sum((X[target_id, :] - X[sample_ids, :])**2, axis=1).T

--- a/src/csne/maxent_comb.py
+++ b/src/csne/maxent_comb.py
@@ -8,7 +8,7 @@ from __future__ import division
 from __future__ import print_function
 import numpy as np
 from csne.weighted_lin_constr import *
-from tqdm import tqdm
+from tqdm import trange, tqdm
 from collections import defaultdict
 import time
 
@@ -170,7 +170,7 @@ class MaxentCombined:
         c_idx = self.__n + c_idx
 
         # Iterate
-        for i in tqdm(range(max_iter)):
+        for i in trange(max_iter, desc='Iterations'):
 
             # Reset alpha every few iterations
             if i % 10 == 0:
@@ -202,14 +202,14 @@ class MaxentCombined:
             # Show the norms of the gradient and objective
             if verbose:
                 #print(np.linalg.norm(grad))
-                print("\nGradient norm: {} in iter {}".format(np.linalg.norm(grad), i))
-                print("Objective: {} in iter {}".format(obj, i))
+                tqdm.write("[iter {}] Gradient norm: {}".format(i, np.linalg.norm(grad)))
+                tqdm.write("[iter {}] Objective: {}".format(i, obj))
 
             if np.linalg.norm(grad, np.inf) < tol:
                 break
 
-        print("Gradient norm: {}".format(np.linalg.norm(grad)))
-        print("Objective: {}".format(obj))
+        tqdm.write("Gradient norm: {}".format(np.linalg.norm(grad)))
+        tqdm.write("Objective: {}".format(obj))
         return x
 
     def _get_sums_sp(self, P, f_pow=False):

--- a/src/csne/maxent_comb.py
+++ b/src/csne/maxent_comb.py
@@ -200,14 +200,14 @@ class MaxentCombined:
             # Show the norms of the gradient and objective
             if verbose:
                 #print(np.linalg.norm(grad))
-                tqdm.write("[iter {}] Gradient norm: {}".format(i, np.linalg.norm(grad)))
-                tqdm.write("[iter {}] Objective: {}".format(i, obj))
+                tqdm.write("[iter {}] Gradient norm: {:.2f}".format(i, np.linalg.norm(grad)))
+                tqdm.write("[iter {}] Objective: {:.2f}".format(i, obj))
 
             if np.linalg.norm(grad, np.inf) < tol:
                 break
 
-        tqdm.write("Gradient norm: {}".format(np.linalg.norm(grad)))
-        tqdm.write("Objective: {}".format(obj))
+        tqdm.write("Final gradient norm: {:.2f}".format(np.linalg.norm(grad)))
+        tqdm.write("Final objective: {:.2f}".format(obj))
         return x
 
     def _get_sums_sp(self, P, f_pow=False):

--- a/src/csne/maxent_comb.py
+++ b/src/csne/maxent_comb.py
@@ -154,8 +154,6 @@ class MaxentCombined:
         """
         Computes teh MaxEnt prior. Uses hessian information o speed up convergence.
         """
-
-        print("Starting optimization...")
         alpha = alpha_init
 
         # Initialize P
@@ -170,7 +168,7 @@ class MaxentCombined:
         c_idx = self.__n + c_idx
 
         # Iterate
-        for i in trange(max_iter, desc='Iterations'):
+        for i in trange(max_iter, desc='Fitting prior'):
 
             # Reset alpha every few iterations
             if i % 10 == 0:


### PR DESCRIPTION
This PR uses tqdm to output logging during the fitting of the prior and training of the CSNE model since it allows for the progress bar to be unbroken. It also adds a progress bar to the training of the CSNE model