### PR TITLE
Use numpy.logaddexp to avoid numerical instability

### DIFF
--- a/src/csne/maxent_comb.py
+++ b/src/csne/maxent_comb.py
@@ -190,11 +190,10 @@ class MaxentCombined:
                 v = x_test[r_idx] + x_test[c_idx]
                 for fi in range(self.__nfuncs):
                     v += self.__F[fi].maskdF * x_test[self.__2n + fi]
-                v = np.exp(v)
-                obj_test = np.sum(np.log(1 + v)) - np.dot(x_test, self.__cs)
+                obj_test = np.sum(np.logaddexp(0, v)) - np.dot(x_test, self.__cs)
                 if obj_test <= obj - (alpha * imp):
                     x = x_test
-                    aux = v
+                    aux = np.exp(v)
                     obj = obj_test
                     break
                 alpha = alpha / 2.0


### PR DESCRIPTION
`numpy.logaddexp(x, y)` is a more numerically stable way to calculate `numpy.log(numpy.exp(x) + numpy.exp(y))`. Since `1 == numpy.exp(0)`, `numpy.logaddexp(0, v) == numpy.log(1 + numpy.exp(v))`. This can be replaced into the offending code in #4.

See also: https://numpy.org/doc/stable/reference/generated/numpy.logaddexp.html

Caveat: this doesn't solve the problem where the `numpy.exp(v)` still has to be calculated to assign into `aux`
