### PR TITLE
Apply `black` code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CSNE: Conditional Signed Network Embedding
 
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 This repository contains the source code, installation and use instructions for the method presented in the paper: 
 *CSNE: Conditional Signed Network Embedding*. Instructions for replicating 
 the experiments in the paper are also given.

--- a/src/csne/csne.py
+++ b/src/csne/csne.py
@@ -29,13 +29,13 @@ class CSNE:
     def __init__(self, A, params, prior, samplemask=None):
         self.__A = A
         self.__n = A.shape[0]
-        self.__d = params['d']
-        self.__k = params['k']
-        self.__s1 = params['s1']
-        self.__s2 = params['s2']
+        self.__d = params["d"]
+        self.__k = params["k"]
+        self.__s1 = params["s1"]
+        self.__s2 = params["s2"]
         self.__params = params
-        self.__diff_inv_sp2 = (1/self.__s1**2 - 1/self.__s2**2)
-        self.__s1_div_s2 = self.__s1/self.__s2
+        self.__diff_inv_sp2 = 1 / self.__s1 ** 2 - 1 / self.__s2 ** 2
+        self.__s1_div_s2 = self.__s1 / self.__s2
         self.__prior = prior
         self._compute_adj_list(A)
         self._sample_ids(samplemask)
@@ -45,7 +45,8 @@ class CSNE:
         self.__adj_list = []
         for i in range(__csr_A.shape[0]):
             self.__adj_list.append(
-                __csr_A.indices[__csr_A.indptr[i]:__csr_A.indptr[i+1]])
+                __csr_A.indices[__csr_A.indptr[i] : __csr_A.indptr[i + 1]]
+            )
 
     def get_sample_ids(self, i):
         return self.__sample_ids_list[i]
@@ -59,18 +60,28 @@ class CSNE:
         self.__num_pos_sample_list = []
         self.__prior_ratio = []
 
-        for i in trange(self.__n, desc='Neighborhood sampling'):
+        for i in trange(self.__n, desc="Neighborhood sampling"):
             if samplemask is None:
                 samples = []
                 pos_ids = self.__adj_list[i]
                 num_pos_samples = min(len(pos_ids), self.__k)
                 if num_pos_samples != 0:
-                    samples.extend(pos_ids[np.random.choice(len(pos_ids), num_pos_samples)])
+                    samples.extend(
+                        pos_ids[np.random.choice(len(pos_ids), num_pos_samples)]
+                    )
                 self.__num_pos_sample_list.append(num_pos_samples)
 
-                samples.extend(list(set(
-                    np.random.randint(self.__n,
-                                      size=(1, 2 * self.__k - num_pos_samples))[0]) - set(pos_ids) - set({i})))
+                samples.extend(
+                    list(
+                        set(
+                            np.random.randint(
+                                self.__n, size=(1, 2 * self.__k - num_pos_samples)
+                            )[0]
+                        )
+                        - set(pos_ids)
+                        - set({i})
+                    )
+                )
 
                 edge_mask = np.zeros_like(samples).astype(bool)
                 edge_mask[:num_pos_samples] = True
@@ -89,22 +100,29 @@ class CSNE:
                 aux = row[sample_ids]
                 self.__edge_masks.append(aux > 0.5)
                 P = self.__prior.get_row_probability(i, sample_ids)
-                self.__prior_ratio.append((1-P)/P)
+                self.__prior_ratio.append((1 - P) / P)
 
     def _compute_squared_dist(self, X, target_id, sample_ids):
-        return np.sum((X[target_id, :] - X[sample_ids, :])**2, axis=1).T
+        return np.sum((X[target_id, :] - X[sample_ids, :]) ** 2, axis=1).T
 
     def _eval_obj(self, X):
-        obj = 0.
+        obj = 0.0
         for i in range(self.__n):
             sample_ids = self.__sample_ids_list[i]
             edge_mask = self.__edge_masks[i]
 
             diff = (X[i, :] - X[sample_ids, :]).T
-            D = np.sum(diff**2, axis=0)
-            P_aij_X = 1. / (1 + self.__s1_div_s2 * self.__prior_ratio[i] * np.exp(self.__diff_inv_sp2 * D / 2))
+            D = np.sum(diff ** 2, axis=0)
+            P_aij_X = 1.0 / (
+                1
+                + self.__s1_div_s2
+                * self.__prior_ratio[i]
+                * np.exp(self.__diff_inv_sp2 * D / 2)
+            )
 
-            obj += np.sum(np.log(P_aij_X[edge_mask] + 1e-20)) + np.sum(np.log(1-P_aij_X[~edge_mask] + 1e-20))
+            obj += np.sum(np.log(P_aij_X[edge_mask] + 1e-20)) + np.sum(
+                np.log(1 - P_aij_X[~edge_mask] + 1e-20)
+            )
 
         return obj
 
@@ -115,8 +133,13 @@ class CSNE:
             edge_mask = self.__edge_masks[i]
 
             diff = (X[i, :] - X[sample_ids, :]).T
-            D = np.sum(diff**2, axis=0)
-            P_aij_X = 1. / (1 + self.__s1_div_s2 * self.__prior_ratio[i] * np.exp(self.__diff_inv_sp2 * D / 2))
+            D = np.sum(diff ** 2, axis=0)
+            P_aij_X = 1.0 / (
+                1
+                + self.__s1_div_s2
+                * self.__prior_ratio[i]
+                * np.exp(self.__diff_inv_sp2 * D / 2)
+            )
 
             grad_i = 2 * self.__diff_inv_sp2 * ((P_aij_X - edge_mask) * diff).T
             grad[i, :] += np.sum(grad_i, axis=0)
@@ -128,47 +151,71 @@ class CSNE:
             X = self.__emb
         P = self.__prior.get_row_probability(row_id, col_ids)
         D = self._compute_squared_dist(X, row_id, col_ids)
-        return 1. / (1 + self.__s1_div_s2 * (1 - P) / P * np.exp(self.__diff_inv_sp2 * D / 2))
+        return 1.0 / (
+            1 + self.__s1_div_s2 * (1 - P) / P * np.exp(self.__diff_inv_sp2 * D / 2)
+        )
 
-    def optimizer_adam(self, X, num_epochs=100, alpha=0.001, beta_1=0.9,
-                       beta_2=0.9999, eps=1e-8, verbose=True, epsilon=0.01):
+    def optimizer_adam(
+        self,
+        X,
+        num_epochs=100,
+        alpha=0.001,
+        beta_1=0.9,
+        beta_2=0.9999,
+        eps=1e-8,
+        verbose=True,
+        epsilon=0.01,
+    ):
         m_prev = np.zeros_like(X)
         v_prev = np.zeros_like(X)
-        for epoch in trange(num_epochs, desc='Training CSNE'):
+        for epoch in trange(num_epochs, desc="Training CSNE"):
             grad = -self._eval_grad(X, epsilon=epsilon)
 
             # Adam optimizer
-            m = beta_1*m_prev + (1-beta_1)*grad
-            v = beta_2*v_prev + (1-beta_2)*grad**2
+            m = beta_1 * m_prev + (1 - beta_1) * grad
+            v = beta_2 * v_prev + (1 - beta_2) * grad ** 2
 
             m_prev = m.copy()
             v_prev = v.copy()
 
-            m = m/(1-beta_1**(epoch+1))
-            v = v/(1-beta_2**(epoch+1))
-            X -= alpha*m/(v**.5 + eps)
+            m = m / (1 - beta_1 ** (epoch + 1))
+            v = v / (1 - beta_2 ** (epoch + 1))
+            X -= alpha * m / (v ** 0.5 + eps)
 
             if verbose:
                 if epoch % 1 == 0:
-                    grad_norm = np.sum(grad**2)**.5
-                    tqdm.write('Epoch: {:d}, gradient norm: {:.4f}'.format(epoch, grad_norm))
-                if epoch == num_epochs-1:
-                    grad_norm = np.sum(grad**2)**.5
+                    grad_norm = np.sum(grad ** 2) ** 0.5
+                    tqdm.write(
+                        "Epoch: {:d}, gradient norm: {:.4f}".format(epoch, grad_norm)
+                    )
+                if epoch == num_epochs - 1:
+                    grad_norm = np.sum(grad ** 2) ** 0.5
                     obj = self._eval_obj(X)
-                    tqdm.write('Epoch: {:d}, obj: {:.4f}, gradient norm: {:.4f}'.format(epoch, -obj, grad_norm))
+                    tqdm.write(
+                        "Epoch: {:d}, obj: {:.4f}, gradient norm: {:.4f}".format(
+                            epoch, -obj, grad_norm
+                        )
+                    )
         return X
 
     def fit(self, verbose=True, X0=None):
-            if X0 is None:
-                X = np.random.randn(self.__n, self.__d)
-            else:
-                X = X0
-            optimizer = self.__params["optimizer"]
-            if optimizer["name"] == 'adam':
-                self.__emb = self.optimizer_adam(X, num_epochs=optimizer['max_iter'], alpha=optimizer['lr'],
-                                                 verbose=verbose, epsilon=self.__params.get("epsilon", 0))
-            else:
-                raise ValueError('optimizer {:s} is not implemented.'.format(optimizer["name"]))
+        if X0 is None:
+            X = np.random.randn(self.__n, self.__d)
+        else:
+            X = X0
+        optimizer = self.__params["optimizer"]
+        if optimizer["name"] == "adam":
+            self.__emb = self.optimizer_adam(
+                X,
+                num_epochs=optimizer["max_iter"],
+                alpha=optimizer["lr"],
+                verbose=verbose,
+                epsilon=self.__params.get("epsilon", 0),
+            )
+        else:
+            raise ValueError(
+                "optimizer {:s} is not implemented.".format(optimizer["name"])
+            )
 
     def predict(self, E):
         edge_dict = defaultdict(list)
@@ -183,7 +230,7 @@ class CSNE:
             pred.extend(self.compute_row_posterior(u, edge_dict[u]))
             ids.extend(ids_dict[u])
 
-        return [p for _,p in sorted(zip(ids, pred))]
+        return [p for _, p in sorted(zip(ids, pred))]
 
     def get_embedding(self):
         return self.__emb
@@ -196,6 +243,6 @@ class CSNE:
 
     def get_parameters(self):
         params = self.__params.copy()
-        params['sample_ids_list'] = self.__sample_ids_list
-        params['edge_masks'] = self.__edge_masks
+        params["sample_ids_list"] = self.__sample_ids_list
+        params["edge_masks"] = self.__edge_masks
         return params

--- a/src/csne/main.py
+++ b/src/csne/main.py
@@ -21,72 +21,135 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Run CSNE.")
 
     # Input/output parameters
-    parser.add_argument('--inputgraph', nargs='?',
-                        default='../../data/hp-relations.csv',
-                        help='Input graph path')
-    
-    parser.add_argument('--output', nargs='?',
-                        default='network.emb',
-                        help='Path where the embeddings will be stored.')
+    parser.add_argument(
+        "--inputgraph",
+        nargs="?",
+        default="../../data/hp-relations.csv",
+        help="Input graph path",
+    )
 
-    parser.add_argument('--tr_e', nargs='?', default=None,
-                        help='Path of the input train edges. Default None (in this case returns embeddings)')
+    parser.add_argument(
+        "--output",
+        nargs="?",
+        default="network.emb",
+        help="Path where the embeddings will be stored.",
+    )
 
-    parser.add_argument('--tr_pred', nargs='?', default='tr_pred.csv',
-                        help='Path where the train predictions will be stored. Default tr_pred.csv')
+    parser.add_argument(
+        "--tr_e",
+        nargs="?",
+        default=None,
+        help="Path of the input train edges. Default None (in this case returns embeddings)",
+    )
 
-    parser.add_argument('--te_e', nargs='?', default=None,
-                        help='Path of the input test edges. Default None.')
+    parser.add_argument(
+        "--tr_pred",
+        nargs="?",
+        default="tr_pred.csv",
+        help="Path where the train predictions will be stored. Default tr_pred.csv",
+    )
 
-    parser.add_argument('--te_pred', nargs='?', default='te_pred.csv',
-                        help='Path where the test predictions will be stored. Default te_pred.csv')
+    parser.add_argument(
+        "--te_e",
+        nargs="?",
+        default=None,
+        help="Path of the input test edges. Default None.",
+    )
+
+    parser.add_argument(
+        "--te_pred",
+        nargs="?",
+        default="te_pred.csv",
+        help="Path where the test predictions will be stored. Default te_pred.csv",
+    )
 
     # Prior related parameters
-    parser.add_argument('--prior_tricount', type=int, default=1,
-                        help='Toogles triangle count use in prior. (1) use triangles and node polarity, '
-                             '(0) only node polarity. Default is 1.')
+    parser.add_argument(
+        "--prior_tricount",
+        type=int,
+        default=1,
+        help="Toogles triangle count use in prior. (1) use triangles and node polarity, "
+        "(0) only node polarity. Default is 1.",
+    )
 
-    parser.add_argument('--prior_learning_rate', type=float, default=1.0,
-                        help='Learning rate for prior. Default is 1.0.')
+    parser.add_argument(
+        "--prior_learning_rate",
+        type=float,
+        default=1.0,
+        help="Learning rate for prior. Default is 1.0.",
+    )
 
-    parser.add_argument('--prior_epochs', type=int, default=10,
-                        help='Training epochs for prior. Default is 100.')
+    parser.add_argument(
+        "--prior_epochs",
+        type=int,
+        default=10,
+        help="Training epochs for prior. Default is 100.",
+    )
 
-    parser.add_argument('--prior_tol', type=float, default=0.0001,
-                        help='Early stop prior fit if grad norm is below this value. Default is 0.0001.')
+    parser.add_argument(
+        "--prior_tol",
+        type=float,
+        default=0.0001,
+        help="Early stop prior fit if grad norm is below this value. Default is 0.0001.",
+    )
 
-    parser.add_argument('--prior_regval', type=float, default=0.9,
-                        help='Regularization value, reduces the certainty about 1s and -1s. Default is 0.9')
+    parser.add_argument(
+        "--prior_regval",
+        type=float,
+        default=0.9,
+        help="Regularization value, reduces the certainty about 1s and -1s. Default is 0.9",
+    )
 
     # Embedding related parameters
-    parser.add_argument('--use_csne', type=int, default=1,
-                        help='Toogle CSNE use. (1) use CSNE, (0) use MaxEnt prior only. Default is 1.')
+    parser.add_argument(
+        "--use_csne",
+        type=int,
+        default=1,
+        help="Toogle CSNE use. (1) use CSNE, (0) use MaxEnt prior only. Default is 1.",
+    )
 
-    parser.add_argument('--learning_rate', type=float, default=0.1,
-                        help='Learning rate for CSNE. Default is 0.1.')
+    parser.add_argument(
+        "--learning_rate",
+        type=float,
+        default=0.1,
+        help="Learning rate for CSNE. Default is 0.1.",
+    )
 
-    parser.add_argument('--epochs', type=int, default=500,
-                        help='Training epochs for CSNE. Default is 500.')
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=500,
+        help="Training epochs for CSNE. Default is 500.",
+    )
 
-    parser.add_argument('--s1', type=float, default=1,
-                        help='Sigma 1. Default is 1.')
+    parser.add_argument("--s1", type=float, default=1, help="Sigma 1. Default is 1.")
 
-    parser.add_argument('--s2', type=float, default=2,
-                        help='Sigma 2. Default is 2.')
+    parser.add_argument("--s2", type=float, default=2, help="Sigma 2. Default is 2.")
 
-    parser.add_argument('--dimension', type=int, default=2,
-                        help='Dimensionality of the CSNE embeddings. Default is 2.')
+    parser.add_argument(
+        "--dimension",
+        type=int,
+        default=2,
+        help="Dimensionality of the CSNE embeddings. Default is 2.",
+    )
 
     # Other parameters
-    parser.add_argument('--delimiter', default=',',
-                        help='Delimiter used in the input files.')
+    parser.add_argument(
+        "--delimiter", default=",", help="Delimiter used in the input files."
+    )
 
-    parser.add_argument('--directed', action='store_true',
-                        help='If specified, network treated as directed. Default is undirected.')
+    parser.add_argument(
+        "--directed",
+        action="store_true",
+        help="If specified, network treated as directed. Default is undirected.",
+    )
     parser.set_defaults(directed=False)
 
-    parser.add_argument('--verbose', action='store_true',
-                        help='Determines the verbosity level of the output.')
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Determines the verbosity level of the output.",
+    )
     parser.set_defaults(verbose=False)
 
     return parser.parse_args()
@@ -116,19 +179,33 @@ def main_helper(args):
     # Fit MaxEnt prior
     start = time.time()
     if args.prior_tricount:
-        mc = MaxentCombined(tr_A.tocsr(), mask, ['cpp', 'cpm', 'cmm'], 'quadratic', args.prior_regval)
+        mc = MaxentCombined(
+            tr_A.tocsr(), mask, ["cpp", "cpm", "cmm"], "quadratic", args.prior_regval
+        )
     else:
-        mc = MaxentCombined(tr_A.tocsr(), mask, [], 'quadratic', args.prior_regval)
-    mc.fit(optimizer='newton', lr=args.prior_learning_rate, max_iter=args.prior_epochs, tol=args.prior_tol,
-           verbose=args.verbose)
+        mc = MaxentCombined(tr_A.tocsr(), mask, [], "quadratic", args.prior_regval)
+    mc.fit(
+        optimizer="newton",
+        lr=args.prior_learning_rate,
+        max_iter=args.prior_epochs,
+        tol=args.prior_tol,
+        verbose=args.verbose,
+    )
     predict_obj = mc
 
     # Fit CSNE
     if args.use_csne:
         tr_A[tr_A == -1] = 0
         tr_A.eliminate_zeros()
-        opt_params = {'name': 'adam', 'lr': args.learning_rate, 'max_iter': args.epochs}
-        params = {'d': args.dimension, 'k': 100, 's1': args.s1, 's2': args.s2, 'optimizer': opt_params, 'epsilon': 0.0}
+        opt_params = {"name": "adam", "lr": args.learning_rate, "max_iter": args.epochs}
+        params = {
+            "d": args.dimension,
+            "k": 100,
+            "s1": args.s1,
+            "s2": args.s2,
+            "optimizer": opt_params,
+            "epsilon": 0.0,
+        }
         csne = CSNE(tr_A, params, mc, mask)
         csne.fit()
         predict_obj = csne
@@ -147,16 +224,20 @@ def main_helper(args):
             pred_te = predict_obj.predict(test_edges)
             np.savetxt(args.te_pred, pred_te, delimiter=args.delimiter)
 
-    # If tr_e!=None or te_e!=None, output predictions for those edges. 
+    # If tr_e!=None or te_e!=None, output predictions for those edges.
     # Else, store the embeddings (if use_csne=1) or store posterior (if use_csne=0)
     else:
         if args.use_csne:
             print("Saving CSNE node embeddings...")
-            np.savetxt(args.output, predict_obj.get_embedding(), delimiter=args.delimiter)
+            np.savetxt(
+                args.output, predict_obj.get_embedding(), delimiter=args.delimiter
+            )
         else:
             print("Saving MaxEnt posterior...")
-            np.savetxt(args.output, predict_obj.get_posterior(), delimiter=args.delimiter)
-    print('Prediction time: {}'.format(time.time()-start))
+            np.savetxt(
+                args.output, predict_obj.get_posterior(), delimiter=args.delimiter
+            )
+    print("Prediction time: {}".format(time.time() - start))
 
 
 def main():

--- a/src/csne/weighted_lin_constr.py
+++ b/src/csne/weighted_lin_constr.py
@@ -42,7 +42,6 @@ class WeightLinConstr:
 
 
 class Uniform(WeightLinConstr):
-
     def __init__(self, A):
         # If adj matrix is not sparse, make it sparse
         if not issparse(A):
@@ -71,7 +70,7 @@ class Uniform(WeightLinConstr):
         return mat.sum() * self.__F
 
     def sqmat_sum_mult(self, mat):
-        return mat.sum() * self.__F**2
+        return mat.sum() * self.__F ** 2
 
     def get_row(self, i):
         return np.ones(self.__n) * self.__F
@@ -84,7 +83,6 @@ class Uniform(WeightLinConstr):
 
 
 class CommonNeigh(WeightLinConstr):
-
     def __init__(self, A):
         # If adj matrix is not sparse, make it sparse
         if not issparse(A):
@@ -97,7 +95,9 @@ class CommonNeigh(WeightLinConstr):
 
     @staticmethod
     def _compute_f(A):
-        F = A.dot(A.T)        # for dir networks A.dot(A) give in degree and A.dot(A.T) gives out degree
+        F = A.dot(
+            A.T
+        )  # for dir networks A.dot(A) give in degree and A.dot(A.T) gives out degree
         F.setdiag(0)
         F.eliminate_zeros()
         F.sort_indices()
@@ -127,13 +127,12 @@ class CommonNeigh(WeightLinConstr):
 
 
 class cpp(CommonNeigh):
-
     @staticmethod
     def _compute_f(A):
         """ Counts the number of ++ wedges in A. """
         # Compute matrix B as the 'mask'
         B = A.copy()
-        B.data = (B.data + 1)/2.0
+        B.data = (B.data + 1) / 2.0
         B.eliminate_zeros()
         # Compute pp wedges
         F = B.dot(B.T)
@@ -143,13 +142,12 @@ class cpp(CommonNeigh):
 
 
 class cmm(CommonNeigh):
-
     @staticmethod
     def _compute_f(A):
         """ Counts the number of -- wedges in A. """
         # Compute matrix B as the 'mask'
         B = A.copy()
-        B.data = np.abs((B.data - 1)/2.0)
+        B.data = np.abs((B.data - 1) / 2.0)
         B.eliminate_zeros()
         # Compute mm wedges
         F = B.dot(B.T)
@@ -159,7 +157,6 @@ class cmm(CommonNeigh):
 
 
 class cpm(CommonNeigh):
-
     @staticmethod
     def _compute_f(A):
         """ Counts the number of +- wedges in A. """
@@ -168,7 +165,7 @@ class cpm(CommonNeigh):
         B.data = np.abs(B.data)
         # Compute cn and subtract those which have the same sign, pp or mm. this leaves you with wedges pm.
         cn = B.dot(B.T)
-        F = (cn - A.dot(A.T))/2.0
+        F = (cn - A.dot(A.T)) / 2.0
         F.setdiag(0)
         F.eliminate_zeros()
         return F


### PR DESCRIPTION
Right now, the code has a pretty inconsistent style which makes it difficult to navigate. I applied the [`black`](https://github.com/psf/black) tool to the source directory with `black src/` to automatically reformat the code. This tool guarantees the same AST, so the code still works exactly the same way.